### PR TITLE
fix: Replace invalid TaskListRegular icon

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -24,7 +24,7 @@ import {
   Link,
 } from '@fluentui/react-components'
 import {
-  TaskListRegular,
+  TaskListAddRegular,
   PersonRegular,
   CheckmarkCircleRegular,
   ClockRegular,
@@ -210,7 +210,7 @@ export default function DashboardPage() {
         <div className={styles.grid}>
           <Card className={styles.statsCard}>
             <div className={styles.cardHeader}>
-              <TaskListRegular />
+              <TaskListAddRegular />
               <Text size={400} weight="semibold">Total Issues</Text>
             </div>
             <div className={styles.statValue}>{stats.total}</div>

--- a/app/(dashboard)/issues/page.tsx
+++ b/app/(dashboard)/issues/page.tsx
@@ -40,7 +40,7 @@ import {
   AddRegular,
   SearchRegular,
   BugRegular,
-  TaskListRegular,
+  TaskListAddRegular,
   PersonRegular,
   CalendarRegular,
 } from '@fluentui/react-icons'
@@ -182,11 +182,11 @@ export default function IssuesPage() {
     const config = {
       bug: { color: 'danger', icon: <BugRegular /> },
       story: { color: 'success', icon: <PersonRegular /> },
-      task: { color: 'brand', icon: <TaskListRegular /> },
+      task: { color: 'brand', icon: <TaskListAddRegular /> },
       epic: { color: 'important', icon: <CalendarRegular /> },
-      improvement: { color: 'warning', icon: <TaskListRegular /> },
-      sub_task: { color: 'subtle', icon: <TaskListRegular /> },
-    }[type] || { color: 'brand', icon: <TaskListRegular /> }
+      improvement: { color: 'warning', icon: <TaskListAddRegular /> },
+      sub_task: { color: 'subtle', icon: <TaskListAddRegular /> },
+    }[type] || { color: 'brand', icon: <TaskListAddRegular /> }
 
     return <Badge appearance={config.color as any} icon={config.icon}>{type.replace('_', ' ')}</Badge>
   }

--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -21,7 +21,7 @@ import {
 } from '@fluentui/react-components'
 import {
   BoardRegular,
-  TaskListRegular,
+  TaskListAddRegular,
   PeopleRegular,
   SettingsRegular,
   SignOutRegular,
@@ -100,7 +100,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const navItems = [
     { id: 'dashboard', icon: <HomeRegular />, label: 'Dashboard', href: '/dashboard' },
     { id: 'board', icon: <BoardRegular />, label: 'Board', href: '/board' },
-    { id: 'issues', icon: <TaskListRegular />, label: 'Issues', href: '/issues' },
+    { id: 'issues', icon: <TaskListAddRegular />, label: 'Issues', href: '/issues' },
     { id: 'team', icon: <PeopleRegular />, label: 'Team', href: '/team' },
     { id: 'projects', icon: <AppsRegular />, label: 'Projects', href: '/projects' },
   ]


### PR DESCRIPTION
Replaces the `TaskListRegular` icon with `TaskListAddRegular` across the application to resolve a build failure. The `TaskListRegular` icon is not available in the current version of `@fluentui/react-icons`, causing the Vercel deployment to fail.

This commit updates the icon in the following components:
- `app/(dashboard)/dashboard/page.tsx`
- `app/(dashboard)/issues/page.tsx`
- `components/DashboardLayout.tsx`